### PR TITLE
Update example in docs

### DIFF
--- a/docs/setting_databricks_connect.rst
+++ b/docs/setting_databricks_connect.rst
@@ -82,7 +82,8 @@ parquet file is listed below.
             secret_key='AzureProjectServicePrincipalSecret',
             workspace='dev',
         ),
-        account_url=storage_account_url,
+        azure_tenant_id='<AAD-tenant-ID>', # Your organisation AAD tenant ID
+        account_url='<storage_account_url>', # URL to your storage account
     )
 
     # Run SQL statement on cluster and save results as a pandas.DataFrame


### PR DESCRIPTION
Updates an example by adding required `azure_tenant_id` field in Blob connection set up.